### PR TITLE
Add a placeholder for GoDaddy API key

### DIFF
--- a/src/bg/alertpage/js/main.js
+++ b/src/bg/alertpage/js/main.js
@@ -1,5 +1,6 @@
 if( window.location.hash ) {
     var hash = window.location.hash.substring(1); //Puts hash in variable, and removes the # character
+    hash = decodeURIComponent(hash);
     var fire_details = JSON.parse( hash );
     console.log( fire_details );
     document.getElementById( "vulnerable_domain" ).innerText = fire_details[ "base_domain" ];

--- a/src/bg/background.js
+++ b/src/bg/background.js
@@ -88,5 +88,6 @@ function godaddy_domain_check( domain, cb ) {
     }
     xhr.open( "GET", "https://api.ote-godaddy.com/v1/domains/available?domain=" + encodeURIComponent( domain ) + "&checkType=FULL&forTransfer=false", true );
     xhr.setRequestHeader( "Accept", "application/json" );
+    xhr.setRequestHeader( "Authorization", "sso-key [API KEY]:[SECRET]" );
     xhr.send( null );
 }


### PR DESCRIPTION
GoDaddy now requires an API key and Domainr requires a credit card in order to get a client_id.

I added a placeholder and also corrected an issue with parsing json on the error page. 